### PR TITLE
nix: add flake

### DIFF
--- a/.github/workflows/gomod2nix.yml
+++ b/.github/workflows/gomod2nix.yml
@@ -1,0 +1,43 @@
+# Workflow originally from https://github.com/AvengeMedia/danklinux/blob/4a70b1c7366bddcaf1ce209a5132fad259cb2460/.github/workflows/gomod2nix.yml
+# under the MIT license
+
+name: Gomod2nix
+
+on:
+  push:
+    paths:
+      - "go.mod"
+      - "go.sum"
+
+jobs:
+  update-gomod2nix_toml:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: cachix/install-nix-action@v31
+    - name: Update gomod2nix.toml
+      run: nix run github:nix-community/gomod2nix/v1.7.0 --override-input nixpkgs nixpkgs
+    - name: Commit and push gomod2nix.toml update
+      run: |
+        set -euo pipefail
+
+        if ! git diff --quiet; then
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add gomod2nix.toml
+          git commit -m "nix: update gomod2nix.toml"
+
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "Successfully pushed gomod2nix.toml update"
+              exit 0
+            fi
+            echo "Push attempt $attempt failed, pulling and retrying..."
+            git pull --rebase
+            sleep $((attempt*2))
+          done
+
+          echo "Failed to push after retries" >&2
+          exit 1
+        fi

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,83 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1756047880,
+        "narHash": "sha256-JeuGh9kA1SPL70fnvpLxkIkCWpTjtoPaus3jzvdna0k=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "47d628dc3b506bd28632e47280c6b89d3496909d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v1.7.0",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+{
+  description = "Indexed filesystem search in GO";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    gomod2nix = {
+      url = "github:nix-community/gomod2nix/v1.7.0";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self, nixpkgs, gomod2nix }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems =
+        f:
+        builtins.listToAttrs (
+          map (system: {
+            name = system;
+            value = f system;
+          }) supportedSystems
+        );
+
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          lib = pkgs.lib;
+          dsearchVersion = "0.0.7";
+        in
+        {
+          dsearch = gomod2nix.legacyPackages.${system}.buildGoApplication {
+            pname = "dsearch";
+            version = dsearchVersion;
+            src = ./.;
+            modules = ./gomod2nix.toml;
+
+            subPackages = [ "cmd/dsearch" ];
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.Version=${dsearchVersion}"
+            ];
+
+            postPatch = ''
+              substituteInPlace assets/dsearch.service \
+                --replace-fail /usr/local/bin $out/bin
+            '';
+
+            postInstall = ''              
+              install -Dm 644 assets/dsearch.service -t $out/lib/systemd/user
+            '';
+
+            meta = {
+              description = "Indexed filesystem search in GO";
+              homepage = "https://github.com/AvengeMedia/danksearch";
+              mainProgram = "dsearch";
+              license = lib.licenses.mit;
+              platforms = lib.platforms.unix;
+            };
+          };
+
+          default = self.packages.${system}.dsearch;
+        }
+      );
+    };
+}

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,156 @@
+schema = 3
+
+[mod]
+  [mod."github.com/BurntSushi/toml"]
+    version = "v1.5.0"
+    hash = "sha256-wX8bEVo7swuuAlm0awTIiV1KNCAXnm7Epzwl+wzyqhw="
+  [mod."github.com/RoaringBitmap/roaring/v2"]
+    version = "v2.4.5"
+    hash = "sha256-igWY0S1PTolQkfctYcmVJioJyV1pk2V81X6o6BA1XQA="
+  [mod."github.com/aymanbagabas/go-osc52/v2"]
+    version = "v2.0.1"
+    hash = "sha256-6Bp0jBZ6npvsYcKZGHHIUSVSTAMEyieweAX2YAKDjjg="
+  [mod."github.com/bits-and-blooms/bitset"]
+    version = "v1.22.0"
+    hash = "sha256-lY1K29h4vlAmJVvwKgbTG8BTACYGjFaginCszN+ST6w="
+  [mod."github.com/blevesearch/bleve/v2"]
+    version = "v2.5.4"
+    hash = "sha256-SvlPvZ3H0xY3KwW/7XKJFTM7MsgWVL4nkrfd3le5Xh8="
+  [mod."github.com/blevesearch/bleve_index_api"]
+    version = "v1.2.10"
+    hash = "sha256-1lC62MFXNuZ9NvvsAC18zGM+IXaPHXqyF2vmSTzJLJ8="
+  [mod."github.com/blevesearch/geo"]
+    version = "v0.2.4"
+    hash = "sha256-W1OV/pvqzJC28VJomGnIU/HeBZ689+p54vWdZ1z/bxc="
+  [mod."github.com/blevesearch/go-faiss"]
+    version = "v1.0.25"
+    hash = "sha256-bcm976UX22aNIuSjBxFaYMKTltO9lbqyeG4Z3KVG3/Y="
+  [mod."github.com/blevesearch/go-porterstemmer"]
+    version = "v1.0.3"
+    hash = "sha256-hUjo6g1ehUD1awBmta0ji/xoooD2qG7O22HIeSQiRFo="
+  [mod."github.com/blevesearch/gtreap"]
+    version = "v0.1.1"
+    hash = "sha256-B4p/5RnECRfV4yOiSQDLMHb23uI7lsQDePhNK+zjbF4="
+  [mod."github.com/blevesearch/mmap-go"]
+    version = "v1.0.4"
+    hash = "sha256-8y0nMAE9goKjYhR/FFEvtbP7cvM46xneE461L1Jn2Pg="
+  [mod."github.com/blevesearch/scorch_segment_api/v2"]
+    version = "v2.3.12"
+    hash = "sha256-C9yB9jK37Wc9pjWOmZjcEnnhYn1wVDvWiOfw4sbFCrg="
+  [mod."github.com/blevesearch/segment"]
+    version = "v0.9.1"
+    hash = "sha256-0EAT737kNxl8IJFGl2SD9mOzxolONGgpfaYEGr7JXkQ="
+  [mod."github.com/blevesearch/snowballstem"]
+    version = "v0.9.0"
+    hash = "sha256-NQsXrhXcYXn4jQcvwjwLc96SGMRcqVlrR6hYKWGk7/s="
+  [mod."github.com/blevesearch/upsidedown_store_api"]
+    version = "v1.0.2"
+    hash = "sha256-P69Mnh6YR5RI73bD6L7BYDxkVmaqPMNUrjbfSJoKWuo="
+  [mod."github.com/blevesearch/vellum"]
+    version = "v1.1.0"
+    hash = "sha256-GJ1wslEJEZhPbMiANw0W4Dgb1ZouiILbWEaIUfxZTkw="
+  [mod."github.com/blevesearch/zapx/v11"]
+    version = "v11.4.2"
+    hash = "sha256-YzRcc2GwV4VL2Bc+tXOOUL6xNi8LWS76DXEcTkFPTaQ="
+  [mod."github.com/blevesearch/zapx/v12"]
+    version = "v12.4.2"
+    hash = "sha256-yqyzkMWpyXZSF9KLjtiuOmnRUfhaZImk27mU8lsMyJY="
+  [mod."github.com/blevesearch/zapx/v13"]
+    version = "v13.4.2"
+    hash = "sha256-VSS2fI7YUkeGMBH89TB9yW5qG8MWjM6zKbl8DboHsB4="
+  [mod."github.com/blevesearch/zapx/v14"]
+    version = "v14.4.2"
+    hash = "sha256-mAWr+vK0uZWMUaJfGfchzQo4dzMdBbD3Z7F84Jn/ktg="
+  [mod."github.com/blevesearch/zapx/v15"]
+    version = "v15.4.2"
+    hash = "sha256-R8Eh3N4e8CDXiW47J8ZBnfMY1TTnX1SJPwQc4gYChi8="
+  [mod."github.com/blevesearch/zapx/v16"]
+    version = "v16.2.6"
+    hash = "sha256-8b3jMCCKOz8Biven8VTe9wxPVxbdnvGfZ3ccvK/0WA0="
+  [mod."github.com/charmbracelet/colorprofile"]
+    version = "v0.2.3-0.20250311203215-f60798e515dc"
+    hash = "sha256-D9E/bMOyLXAUVOHA1/6o3i+vVmLfwIMOWib6sU7A6+Q="
+  [mod."github.com/charmbracelet/lipgloss"]
+    version = "v1.1.0"
+    hash = "sha256-RHsRT2EZ1nDOElxAK+6/DC9XAaGVjDTgPvRh3pyCfY4="
+  [mod."github.com/charmbracelet/log"]
+    version = "v0.4.2"
+    hash = "sha256-3w1PCM/c4JvVEh2d0sMfv4C77Xs1bPa1Ea84zdynC7I="
+  [mod."github.com/charmbracelet/x/ansi"]
+    version = "v0.8.0"
+    hash = "sha256-/YyDkGrULV2BtnNk3ojeSl0nUWQwIfIdW7WJuGbAZas="
+  [mod."github.com/charmbracelet/x/cellbuf"]
+    version = "v0.0.13-0.20250311204145-2c3ea96c31dd"
+    hash = "sha256-XAhCOt8qJ2vR77lH1ez0IVU1/2CaLTq9jSmrHVg5HHU="
+  [mod."github.com/charmbracelet/x/term"]
+    version = "v0.2.1"
+    hash = "sha256-VBkCZLI90PhMasftGw3403IqoV7d3E5WEGAIVrN5xQM="
+  [mod."github.com/danielgtaylor/huma/v2"]
+    version = "v2.34.1"
+    hash = "sha256-GU9ksEvtLppUYUISOWcxh4oD3JcmFgyyQnaPJ+L3cM4="
+  [mod."github.com/fsnotify/fsnotify"]
+    version = "v1.9.0"
+    hash = "sha256-WtpE1N6dpHwEvIub7Xp/CrWm0fd6PX7MKA4PV44rp2g="
+  [mod."github.com/go-chi/chi/v5"]
+    version = "v5.2.3"
+    hash = "sha256-fB8KidqJgWrPnnS+0uIKVOO1VRclD6nG1Lt1IeSq2M0="
+  [mod."github.com/go-logfmt/logfmt"]
+    version = "v0.6.0"
+    hash = "sha256-RtIG2qARd5sT10WQ7F3LR8YJhS8exs+KiuUiVf75bWg="
+  [mod."github.com/golang/snappy"]
+    version = "v0.0.4"
+    hash = "sha256-Umx+5xHAQCN/Gi4HbtMhnDCSPFAXSsjVbXd8n5LhjAA="
+  [mod."github.com/inconshreveable/mousetrap"]
+    version = "v1.1.0"
+    hash = "sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE="
+  [mod."github.com/json-iterator/go"]
+    version = "v1.1.12"
+    hash = "sha256-To8A0h+lbfZ/6zM+2PpRpY3+L6725OPC66lffq6fUoM="
+  [mod."github.com/lucasb-eyer/go-colorful"]
+    version = "v1.2.0"
+    hash = "sha256-Gg9dDJFCTaHrKHRR1SrJgZ8fWieJkybljybkI9x0gyE="
+  [mod."github.com/mattn/go-isatty"]
+    version = "v0.0.20"
+    hash = "sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ="
+  [mod."github.com/mattn/go-runewidth"]
+    version = "v0.0.16"
+    hash = "sha256-NC+ntvwIpqDNmXb7aixcg09il80ygq6JAnW0Gb5b/DQ="
+  [mod."github.com/modern-go/concurrent"]
+    version = "v0.0.0-20180306012644-bacd9c7ef1dd"
+    hash = "sha256-OTySieAgPWR4oJnlohaFTeK1tRaVp/b0d1rYY8xKMzo="
+  [mod."github.com/modern-go/reflect2"]
+    version = "v1.0.2"
+    hash = "sha256-+W9EIW7okXIXjWEgOaMh58eLvBZ7OshW2EhaIpNLSBU="
+  [mod."github.com/mschoch/smat"]
+    version = "v0.2.0"
+    hash = "sha256-DZvUJXjIcta3U+zxzgU3wpoGn/V4lpBY7Xme8aQUi+E="
+  [mod."github.com/muesli/termenv"]
+    version = "v0.16.0"
+    hash = "sha256-hGo275DJlyLtcifSLpWnk8jardOksdeX9lH4lBeE3gI="
+  [mod."github.com/rivo/uniseg"]
+    version = "v0.4.7"
+    hash = "sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo="
+  [mod."github.com/rwcarlsen/goexif"]
+    version = "v0.0.0-20190401172101-9e8deecbddbd"
+    hash = "sha256-AiY2T9hXj6jnfldYDoe4WNr3FldpVTxc3lScR++HOLc="
+  [mod."github.com/spf13/cobra"]
+    version = "v1.10.1"
+    hash = "sha256-OP6wdqk4dvBD8U5aicTkySHZ2s0LWnBo2TST2SmgcpM="
+  [mod."github.com/spf13/pflag"]
+    version = "v1.0.9"
+    hash = "sha256-YAjyYpq5BXCosVJtvYLWFG1t4gma2ylzc7ILLoj/hD8="
+  [mod."github.com/xo/terminfo"]
+    version = "v0.0.0-20220910002029-abceb7e1c41e"
+    hash = "sha256-GyCDxxMQhXA3Pi/TsWXpA8cX5akEoZV7CFx4RO3rARU="
+  [mod."go.etcd.io/bbolt"]
+    version = "v1.4.0"
+    hash = "sha256-nR/YGQjwz6ue99IFbgw/01Pl8PhoOjpKiwVy5sJxlps="
+  [mod."golang.org/x/exp"]
+    version = "v0.0.0-20231006140011-7918f672742d"
+    hash = "sha256-2SO1etTQ6UCUhADR5sgvDEDLHcj77pJKCIa/8mGDbAo="
+  [mod."golang.org/x/sys"]
+    version = "v0.33.0"
+    hash = "sha256-wlOzIOUgAiGAtdzhW/KPl/yUVSH/lvFZfs5XOuJ9LOQ="
+  [mod."google.golang.org/protobuf"]
+    version = "v1.36.6"
+    hash = "sha256-lT5qnefI5FDJnowz9PEkAGylH3+fE+A3DJDkAyy9RMc="


### PR DESCRIPTION
Adds a basic flake for dsearch, based on the one in [danklinux](https://github.com/AvengeMedia/danklinux).

A caveat is that currently the version is hardcoded in the flake, so it would have to be updated in every release, which can be easy to forget updating (like the danklinux one that is [currently outdated](https://github.com/AvengeMedia/danklinux/blob/4a70b1c7366bddcaf1ce209a5132fad259cb2460/flake.nix#L36)).

I don't think it's possible to get the version from the git tag in the flake, so ideally, there would be a VERSION file that would be automatically updated whenever a new tag is pushed, but I couldn't figure out the best way to do that with the current workflow. I'd like some feedback about that part.