### PR TITLE
fix: resolve 'system' deprecation warning in default.nix

### DIFF
--- a/distro/nix/default.nix
+++ b/distro/nix/default.nix
@@ -12,7 +12,7 @@ let
 in {
   options.programs.dsearch = {
     enable = mkEnableOption "danksearch";
-    package = mkPackageOption self.packages.${pkgs.system} "dsearch" { };
+    package = mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} "dsearch" { };
 
     config = mkOption {
       type = types.nullOr tomlFormat.type;


### PR DESCRIPTION
This change replaces the deprecated `pkgs.system` usage with `pkgs.stdenv.hostPlatform.system`.

This eliminates the following evaluation warning during builds:
`evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`