### PR TITLE
Fix log URLs to use correct formatting

### DIFF
--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -101,9 +101,9 @@ func NewHTTP(addr string, indexer api.IndexerInterface, watcher api.WatcherInter
 
 func (s *HTTPServer) Start() error {
 	log.Infof("HTTP server listening on %s", s.server.Addr)
-	log.Infof("API Documentation: http://localhost%s/docs", s.server.Addr)
-	log.Infof("OpenAPI Spec: http://localhost%s/openapi.json", s.server.Addr)
-	log.Infof("Health Check: http://localhost%s/health", s.server.Addr)
+	log.Infof("API Documentation: http://%s/docs", s.server.Addr)
+	log.Infof("OpenAPI Spec: http://%s/openapi.json", s.server.Addr)
+	log.Infof("Health Check: http://%s/health", s.server.Addr)
 
 	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return err


### PR DESCRIPTION
when starting the server the cli prints are literally these:
  INFO HTTP server listening on 127.0.0.1:43654
  INFO API Documentation: http://localhost127.0.0.1:43654/docs
  INFO OpenAPI Spec: http://localhost127.0.0.1:43654/openapi.json
  INFO Health Check: http://localhost127.0.0.1:43654/health

just removing 'localhost' the prints are right and can be clicked to redirect to a browser