### PR TITLE
fix(config): index text files when index_all_files is disabled

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -376,7 +376,12 @@ func (c *Config) ShouldIndexFile(path string) bool {
 		return false
 	}
 
-	return c.IndexAllFiles
+	// When index_all_files is disabled, only index files whose extension is in
+	// text_extensions; otherwise nothing would be indexed at all.
+	if c.IndexAllFiles {
+		return true
+	}
+	return c.IsTextFile(path)
 }
 
 func (c *Config) ShouldIndexDir(path string) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -72,6 +72,45 @@ func (s *ConfigSuite) TestShouldIndexFile() {
 	}
 }
 
+// When index_all_files is false, only files whose extension is in
+// text_extensions should be indexed (see issue #24); non-text files and files
+// without a matching extension must be skipped, but exclusion rules still apply.
+func (s *ConfigSuite) TestShouldIndexFileTextOnly() {
+	cfg := &Config{
+		IndexAllFiles: false,
+		TextExts:      []string{".go", ".md", ".txt"},
+		IndexPaths: []IndexPath{
+			{
+				Path:          "/home/user",
+				MaxDepth:      10,
+				ExcludeHidden: true,
+				ExcludeDirs:   []string{"node_modules", ".git"},
+			},
+		},
+	}
+	cfg.BuildMaps()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"text go file", "/home/user/project/main.go", true},
+		{"text md file", "/home/user/project/README.md", true},
+		{"non-text image", "/home/user/project/photo.jpg", false},
+		{"non-text binary", "/home/user/project/app.exe", false},
+		{"file without extension", "/home/user/project/README", false},
+		{"text file in excluded dir", "/home/user/project/node_modules/index.go", false},
+		{"hidden text file", "/home/user/project/.config.go", false},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.Equal(tt.expected, cfg.ShouldIndexFile(tt.path))
+		})
+	}
+}
+
 func (s *ConfigSuite) TestIsTextFile() {
 	cfg := Default()
 


### PR DESCRIPTION
## Problem

Setting `index_all_files = false` in `config.toml` results in **no files being indexed at all** (reported in #24).

## Root cause

`ShouldIndexFile()` in `internal/config/config.go` ended with `return c.IndexAllFiles`. When `index_all_files` is `false` that returns `false` for every file, so nothing is ever indexed.

Per the [documented behaviour](https://danklinux.com/docs/danksearch/configuration#index_all_files), when `index_all_files = false` only files whose extension is in `text_extensions` should be indexed — but that path was never wired up. `ShouldIndexFile` is the gate for indexing a file at all, while `IsTextFile` (already used at `indexer.go` to decide whether to also index file *content*) checks the extension against `text_extensions`.

## Fix

Fall back to `IsTextFile(path)` when `index_all_files` is disabled:

```go
if c.IndexAllFiles {
    return true
}
return c.IsTextFile(path)
```

`index_all_files = true` (the default) keeps indexing everything, so existing behaviour is unchanged. The hidden-file and `exclude_dirs` checks still run first either way.

Thanks to @OzzyMaul2 for the precise diagnosis and pointing at the exact line.

## Tests

`TestShouldIndexFile` only exercised the `index_all_files = true` case, which is how this slipped through. Added `TestShouldIndexFileTextOnly` covering the `false` path: text-extension files are indexed, non-text / no-extension files are skipped, and exclusion (hidden, `exclude_dirs`) still wins.

The new test fails on the old code (`.go`/`.md` expected to index but didn't) and passes with the fix. Full suite (`go test ./...`) and `go vet` are green.